### PR TITLE
Change deprecated function find_element_by_name

### DIFF
--- a/start.py
+++ b/start.py
@@ -24,9 +24,9 @@ sleep(1)
 webdriver.get('https://www.instagram.com/accounts/login/?source=auth_switcher')
 sleep(2)
 
-username = webdriver.find_element_by_name('username')
+username = webdriver.find_element('username')
 username.send_keys('your_username') # Change this to your own Instagram username
-password = webdriver.find_element_by_name('password')
+password = webdriver.find_element('password')
 password.send_keys('your_password') # Change this to your own Instagram password
 
 button_login = webdriver.find_element_by_xpath('//html//body//div[1]//section//main//div//article//div//div[1]//div//form//div//div[3]//button//div')


### PR DESCRIPTION
Selenium 4.3.0 : Deprecated find_element_by_* and find_elements_by_* are now removed (#10712)